### PR TITLE
SevenZipSharp.Interop.NoReferences: fix naming of targets file for importing to work

### DIFF
--- a/src/SevenZipSharp.Interop.NoReferences.nuspec
+++ b/src/SevenZipSharp.Interop.NoReferences.nuspec
@@ -12,4 +12,9 @@
     <projectUrl>https://github.com/luuksommers/SevenZipSharp.Interop/</projectUrl>
     <tags>7zip SevenZipSharp</tags>
   </metadata>
+  <files>
+    <file src="build\x86\7z.dll" target="build\x86" />
+    <file src="build\x64\7z.dll" target="build\x64" />
+    <file src="build\SevenZipSharp.Interop.targets" target="build\SevenZipSharp.Interop.NoReferences.targets" />
+  </files>
 </package>


### PR DESCRIPTION
By convention NuGet will only import `.targets` file from a package if its name matches the package id.

Previously, for package `SevenZipSharp.Interop.NoReferences` the `.targets` file name was `SevenZipSharp.Interop.targets`, which resulted in NuGet not importing it, and as a result 7z.dll weren't copied to the output folder.

This fixes it by copying the `.targets` file with a correct name. Unfortunately I had to explicitly list all copied files in the `.nuspec` but I think it's acceptable.

I verified this fix locally, now the binaries get copied to the output folder.
